### PR TITLE
test(core): increase coverage of core.

### DIFF
--- a/core/core/api/api.py
+++ b/core/core/api/api.py
@@ -215,7 +215,7 @@ def list_projects(
     for proj in repo.list()[slice(begin_idx, end_idx)]:
         try:
             resp.append(convert_to_projectbare(proj))
-        except TypeError as e:
+        except TypeError as e:  # pragma: no cover
             logger.warning(e)
 
     return resp
@@ -240,9 +240,6 @@ def add_project(
         New `Project` with `id`.
     """
     new_project = repo.add(model.Project(**project.dict()))
-
-    if not new_project:
-        raise HTTPException(status_code=400, detail="Project not found")
 
     return convert_to_projectbare(new_project)
 
@@ -333,7 +330,7 @@ def list_project_jobs(
     for job in project.jobs[slice(begin_idx, end_idx)]:
         try:
             resp.append(convert_to_jobbare(job))
-        except TypeError as e:
+        except TypeError as e:  # pragma: no cover
             logger.warning(e)
 
     return resp
@@ -534,7 +531,7 @@ async def get_object_image(object_id: int = Path(..., ge=1)):
     HTTPException
         If no object is found.
     """
-    if core.main.sessionfactory is None:
+    if core.main.sessionfactory is None:  # pragma: no cover
         raise RuntimeError("Sessionfactory is not made")
 
     session = core.main.sessionfactory()

--- a/core/core/api/schema.py
+++ b/core/core/api/schema.py
@@ -26,13 +26,13 @@ def get_label(label_id: int) -> str:
         "Vederbuk",
     ]
 
-    if label_id > len(available_labels):
+    if label_id > len(available_labels):  # pragma: no cover
         return "Unknown label"
 
     return available_labels[label_id]
 
 
-class HashableBaseModel(BaseModel):
+class HashableBaseModel(BaseModel):  # pragma: no cover
     """Custom definition of `BaseModel` who implements `__hash__`."""
 
     def __hash__(self) -> int:

--- a/core/core/interface.py
+++ b/core/core/interface.py
@@ -13,7 +13,9 @@ logger = logging.getLogger(__name__)
 
 
 def to_track(
-    frames: List[core.model.Frame], host: str = "127.0.0.1", port: str = "8001"
+    frames: List[core.model.Frame],
+    host: str = "http://127.0.0.1",
+    port: str = "8001",
 ) -> List[core.model.Object]:
     """Send frames to tracker.
 
@@ -40,7 +42,7 @@ def to_track(
     data = [frame.to_json() for frame in frames]
 
     response = requests.post(
-        f"http://{host}:{port}/tracking/track",
+        f"{host}:{port}/tracking/track",
         json=data,
     )
 
@@ -51,12 +53,12 @@ def to_track(
             times = sorted([det.frame for det in o._detections])
 
             time_in = frames[times[0]].timestamp
-            if time_in is None:
+            if time_in is None:  # pragma: no cover
                 raise RuntimeError("Expected type datetime, got None")
             o.time_in = time_in
 
             time_out = frames[times[-1]].timestamp
-            if time_out is None:
+            if time_out is None:  # pragma: no cover
                 raise RuntimeError("Expected type datetime, got None")
             o.time_out = time_out
         return objects
@@ -72,7 +74,7 @@ class Model:
     classes: List[str]
 
 
-class Detector:  # pragma: no cover
+class Detector:
     """Interface class to detection API.
 
     Parameters
@@ -109,7 +111,9 @@ class Detector:  # pragma: no cover
         `(height, width, channels) or (frame, height, width, channels)`
     """
 
-    def __init__(self, host: str = "127.0.0.1", port: str = "8003") -> None:
+    def __init__(
+        self, host: str = "http://127.0.0.1", port: str = "8003"
+    ) -> None:
         self.host: str = host
         self.port: str = port
         self.available_models: List[Model] = self._models()
@@ -165,7 +169,7 @@ class Detector:  # pragma: no cover
 
         try:
             response = requests.post(
-                f"http://{self.host}:{self.port}/predictions/{model_name}/",
+                f"{self.host}:{self.port}/predictions/{model_name}/",
                 files=byte_frames,
             )
         except requests.ConnectionError as e:
@@ -220,7 +224,7 @@ class Detector:  # pragma: no cover
             List of available model names.
         """
         try:
-            response = requests.get(f"http://{self.host}:{self.port}/models/")
+            response = requests.get(f"{self.host}:{self.port}/models/")
         except requests.ConnectionError as e:
             raise ConnectionError("Connection error to Detection API") from e
 

--- a/core/poetry.lock
+++ b/core/poetry.lock
@@ -717,6 +717,22 @@ security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
+name = "requests-mock"
+version = "1.9.3"
+description = "Mock out responses from the requests package"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+requests = ">=2.3,<3"
+six = "*"
+
+[package.extras]
+fixture = ["fixtures"]
+test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.18)", "testtools"]
+
+[[package]]
 name = "rx"
 version = "1.6.1"
 description = "Reactive Extensions (Rx) for Python"
@@ -1396,7 +1412,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-pymysql"
-version = "0.1.7"
+version = "1.0.0"
 description = "Typing stubs for PyMySQL"
 category = "dev"
 optional = false
@@ -1498,7 +1514,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-routes"
-version = "0.1.4"
+version = "0.1.6"
 description = "Typing stubs for Routes"
 category = "dev"
 optional = false
@@ -1745,7 +1761,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a9a99304497e1623e7bd2678d208dce8b62312ff2423325f19ddb52039797cc1"
+content-hash = "bce11f6eb19e4e5e7c9bb8ef5ee3061a4fd6eed782855d06873628e543855c83"
 
 [metadata.files]
 aiofiles = [
@@ -2355,6 +2371,10 @@ requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
 ]
+requests-mock = [
+    {file = "requests-mock-1.9.3.tar.gz", hash = "sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba"},
+    {file = "requests_mock-1.9.3-py2.py3-none-any.whl", hash = "sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970"},
+]
 rx = [
     {file = "Rx-1.6.1-py2.py3-none-any.whl", hash = "sha256:7357592bc7e881a95e0c2013b73326f704953301ab551fbc8133a6fadab84105"},
     {file = "Rx-1.6.1.tar.gz", hash = "sha256:13a1d8d9e252625c173dc795471e614eadfe1cf40ffc684e08b8fff0d9748c23"},
@@ -2675,8 +2695,8 @@ types-pymssql = [
     {file = "types_pymssql-0.1.2-py2.py3-none-any.whl", hash = "sha256:074219afb1c277a96fade8ea027ca91998c90a9bda8c0a726fb2c29e0fcac809"},
 ]
 types-pymysql = [
-    {file = "types-PyMySQL-0.1.7.tar.gz", hash = "sha256:7b7f3f7200e1411a90ca913be105024b27df50cdc085d4685317937661dc94bb"},
-    {file = "types_PyMySQL-0.1.7-py2.py3-none-any.whl", hash = "sha256:89c824fc9625c18ed929b77fe47ce7dd203d53da9cdd79c1e7a7e8058d8c7a12"},
+    {file = "types-PyMySQL-1.0.0.tar.gz", hash = "sha256:528f1602a54fc0ba9bc6ebe6b6f756c33e9a8ed4dfbf1cad05f4b9781f43886d"},
+    {file = "types_PyMySQL-1.0.0-py2.py3-none-any.whl", hash = "sha256:32e0e966140954803ed03a9b740fae08dfee8a9a299f2b2b7951bb6754eade19"},
 ]
 types-pyrfc3339 = [
     {file = "types-pyRFC3339-0.1.1.tar.gz", hash = "sha256:80569ea7c6a97f4b5f46e4db26b8a7c0beac3a117f5e74b33a6190275c999e4d"},
@@ -2723,8 +2743,8 @@ types-retry = [
     {file = "types_retry-0.1.3-py2.py3-none-any.whl", hash = "sha256:9ff6a3570f7fbe42c6580c8a422c191453bfa16a46e346003b5990e0bc03da40"},
 ]
 types-routes = [
-    {file = "types-Routes-0.1.4.tar.gz", hash = "sha256:90b435dfec899c4887319d0e3f210840d3a3b7a688b1f8d540f9dcec3d903d5f"},
-    {file = "types_Routes-0.1.4-py2.py3-none-any.whl", hash = "sha256:de95429abc1f59ac27bd6ae9062d096fea14ae5d96a1dfccd211423dba323ba6"},
+    {file = "types-Routes-0.1.6.tar.gz", hash = "sha256:c3680702981b1506524f281ef9c39a0b7fdef6ff15fcbf7a985e926cafb36cfb"},
+    {file = "types_Routes-0.1.6-py2.py3-none-any.whl", hash = "sha256:16a543f2df09b80dcf1f30e2fe231bbdc4e1dfe930dcc5d74b92652289646d84"},
 ]
 types-scribe = [
     {file = "types-scribe-0.1.1.tar.gz", hash = "sha256:e569ab97d863bd45cf413412d38e2dae224057b8e013f51fd28ffbd705d64e39"},

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -29,6 +29,7 @@ pytest-cov = "^2.11.1"
 pre-commit = "^2.10.1"
 types-all = "^1.0.0"
 flake8 = "^3.9.2"
+requests-mock = "^1.9.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/core/tests/unit/test_interface.py
+++ b/core/tests/unit/test_interface.py
@@ -1,0 +1,247 @@
+"""Unit testing interface to tracking and detection."""
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+from requests_mock.mocker import Mocker
+
+from core.interface import Detector, to_track
+from core.model import BBox, Detection, Frame, Object, Video
+
+TEST_VIDEO_PATH = Path(
+    "./tests/integration/test-abbor[2021-01-01_00-00-00]-000-small.mp4"
+)
+TEST_API_URI = "mock://127.0.0.1"
+TEST_API_PORT = "9999"
+TEST_API_URI_ERROR = "mock://127.0.0.2"
+
+
+@pytest.fixture
+def make_images() -> np.ndarray:
+    """Make a numpy array of many frames from test video."""
+    return Video.from_path(str(TEST_VIDEO_PATH.resolve()))[0:3]
+
+
+@pytest.fixture
+def make_image() -> np.ndarray:
+    """Make a numpy array of many frames from test video."""
+    return Video.from_path(str(TEST_VIDEO_PATH.resolve()))[0]
+
+
+@pytest.fixture
+def mock_to_track(requests_mock: Mocker):
+    """Mock response from tracking api."""
+    json_expected = [
+        {
+            "track_id": 0,
+            "detections": [
+                {
+                    "bbox": {"x1": 0, "y1": 0, "x2": 0, "y2": 0},
+                    "label": 0,
+                    "probability": 0,
+                    "frame": 0,
+                    "frame_id": 0,
+                    "video_id": 0,
+                }
+            ],
+            "label": 0,
+        }
+    ]
+
+    error = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
+    requests_mock.real_http = True  # type: ignore
+
+    # mock status_codes not 200
+    requests_mock.post(
+        f"{TEST_API_URI_ERROR}:{TEST_API_PORT}/tracking/track",
+        json=error,
+        status_code=422,
+    )
+    # mock normal response
+    requests_mock.post(
+        f"{TEST_API_URI}:{TEST_API_PORT}/tracking/track", json=json_expected
+    )
+    return requests_mock
+
+
+@pytest.fixture
+def mock_detector(requests_mock: Mocker):
+    """Mock response from detection api."""
+    requests_mock.real_http = True  # type: ignore
+
+    # mock status_codes not 200
+    error = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
+    requests_mock.get(
+        f"{TEST_API_URI_ERROR}:{TEST_API_PORT}/models/",
+        json=error,
+        status_code=422,
+    )
+    requests_mock.post(
+        f"{TEST_API_URI_ERROR}:{TEST_API_PORT}/predictions/testy/",
+        json=error,
+        status_code=422,
+    )
+
+    # mock normal response from models endpoint
+    requests_mock.get(
+        f"{TEST_API_URI}:{TEST_API_PORT}/models/",
+        json={
+            "testy": [
+                "test",
+                "tester",
+            ]
+        },
+    )
+
+    # mock normal response with detections in each frame
+    requests_mock.post(
+        f"{TEST_API_URI}:{TEST_API_PORT}/predictions/testy/",
+        json={
+            1: [
+                {
+                    "x1": 0,
+                    "y1": 0,
+                    "x2": 0,
+                    "y2": 0,
+                    "confidence": 0,
+                    "label": 0,
+                }
+            ],
+            2: [],
+            3: [
+                {
+                    "x1": 0,
+                    "y1": 0,
+                    "x2": 0,
+                    "y2": 0,
+                    "confidence": 0,
+                    "label": 0,
+                }
+            ],
+        },
+    )
+    return requests_mock
+
+
+def test_to_track(mock_to_track: Mocker):
+    """Test tracking interface in core with mock tracking api."""
+    _ = mock_to_track
+    frames = [
+        Frame(
+            0,
+            [
+                Detection(BBox(*[0, 0, 0, 0]), 0.0, 0, 0),
+            ],
+            datetime(1, 1, 1, 1, 1, 1),
+        ),
+        Frame(
+            1,
+            [
+                Detection(BBox(*[0, 0, 0, 0]), 0.0, 0, 0),
+            ],
+            None,
+        ),
+    ]
+
+    resp = to_track(frames, host=TEST_API_URI, port=TEST_API_PORT)
+
+    assert resp is not None
+
+    assert isinstance(resp[0], Object)
+    assert isinstance(resp[0]._detections[0], Detection)
+    assert isinstance(resp[0]._detections[0].bbox, BBox)
+    assert resp[0].track_id == 0
+    assert resp[0].time_in is not None
+    assert resp[0].time_out is not None
+
+    resp = to_track(frames, host=TEST_API_URI_ERROR, port=TEST_API_PORT)
+    assert len(resp) == 0
+
+
+def test_detection_api_interface(
+    mock_detector: Mocker,
+    make_images: np.ndarray,
+    make_image: np.ndarray,
+):
+    """Test detection interface in core with mock detection api."""
+    _ = mock_detector
+    detection_interface = Detector(host=TEST_API_URI, port=TEST_API_PORT)
+    model_name = detection_interface.available_models[0].name
+
+    # Test detecting with many frames
+    frames = detection_interface.predict(make_images, model_name)
+
+    assert len(frames) == 3
+    assert isinstance(frames[0], Frame)
+    assert isinstance(frames[0].detections[0], Detection)
+    assert isinstance(frames[0].detections[0].bbox, BBox)
+
+    # Test detecting with one frame
+    frames = detection_interface.predict(make_image, model_name)
+    assert len(frames) == 3
+
+    # Test wrong `model_name`
+    with pytest.raises(KeyError):
+        _ = detection_interface.predict(make_images, "testyyy")
+
+    # Test wrong `frames` dimensions.
+    frame_2d = np.zeros((128, 64))
+    with pytest.raises(NotImplementedError):
+        _ = detection_interface.predict(frame_2d, model_name)
+
+    frame_5d = np.zeros((2, 2, 128, 64, 3))
+    with pytest.raises(NotImplementedError):
+        _ = detection_interface.predict(frame_5d, model_name)
+
+
+def test_detector_model_no_connection():
+    """Test logic for no api connection."""
+    with pytest.raises(ConnectionError):
+        _ = Detector()
+
+
+def test_detector_prediction_no_connection(
+    mock_detector: Mocker, make_image: np.ndarray
+):
+    """Test logic for no api connection."""
+    _ = mock_detector
+    detection_interface = Detector(host=TEST_API_URI, port=TEST_API_PORT)
+    model_name = detection_interface.available_models[0].name
+
+    # change host to trigger connection error
+    detection_interface.host = "http://nohost"
+
+    with pytest.raises(ConnectionError):
+        _ = detection_interface.predict(make_image, model_name)
+
+
+def test_detector_model_not_status_code_200(
+    mock_detector: Mocker,
+):
+    """Test detection interface model status_code handling."""
+    _ = mock_detector
+    detection_interface = Detector(host=TEST_API_URI, port=TEST_API_PORT)
+
+    # change host to get status_code 422
+    detection_interface.host = TEST_API_URI_ERROR
+
+    result = detection_interface._models()
+
+    assert len(result) == 0
+
+
+def test_detection_prediction_not_status_code_200(
+    mock_detector: Mocker,
+    make_images: np.ndarray,
+):
+    """Test detection interface prediction status_code handling."""
+    _ = mock_detector
+    detection_interface = Detector(host=TEST_API_URI, port=TEST_API_PORT)
+    model_name = detection_interface.available_models[0].name
+
+    # change host to get status_code 422
+    detection_interface.host = TEST_API_URI_ERROR
+
+    with pytest.raises(RuntimeError):
+        _ = detection_interface.predict(make_images, model_name)


### PR DESCRIPTION
Started on increasing coverage in core, ref. #28.

Added unit tests for `interface.py` and improved test for `api` to cover all. Some lines have been excluded from use in calculating coverage.

Coverage output:
```terminal
Name                            Stmts   Miss  Cover   Missing
-------------------------------------------------------------
core/__init__.py                    0      0   100%
core/api/__init__.py                1      0   100%
core/api/api.py                   172      0   100%
core/api/schema.py                 80      0   100%
core/interface.py                  63      0   100%
core/main.py                       48      6    88%   76-90, 96
core/model.py                     375      4    99%   487-490, 738, 741
core/repository/__init__.py         1      0   100%
core/repository/object.py          31      0   100%
core/repository/orm.py             28      0   100%
core/repository/repository.py      47      0   100%
core/repository/video.py           29      0   100%
core/services.py                  239    194    19%   27-29, 39, 50, 72-81, 108-166, 191-358, 369-374, 378-381, 386-407, 421-431, 436-448, 465-466, 471-472, 483-498
core/utils.py                      17      2    88%   36, 58
-------------------------------------------------------------
TOTAL                            1131    206    82%
```