### PR TITLE
feat(core/ui): exposing video_id of object from `core` to `ui`

### DIFF
--- a/src/core/api/schema.py
+++ b/src/core/api/schema.py
@@ -47,9 +47,9 @@ class Object(BaseModel):
     label: str
     probability: float
     detections: Dict[str, List[float]]
-    track_id: int
     time_in: datetime
     time_out: datetime
+    video_ids: List[int]
 
     @validator("label", pre=True)
     def convert_label(cls, label_id: int):

--- a/src/core/model.py
+++ b/src/core/model.py
@@ -8,7 +8,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import cv2 as cv
 import numpy as np
@@ -925,6 +925,21 @@ class Object:
         return [
             (det.frame_id, det.video_id, det.bbox) for det in self._detections
         ]
+
+    @property
+    def video_ids(self) -> List[int]:
+        """Derive all video the object is part of.
+
+        Return
+        ------
+        List[int]
+            List of video id's.
+        """
+        video_id: Set[int] = set()
+        for det in self._detections:
+            if det.video_id is not None:
+                video_id.add(det.video_id)
+        return list(video_id)
 
 
 class Job:

--- a/src/ui/projects/model.py
+++ b/src/ui/projects/model.py
@@ -14,10 +14,10 @@ class Object:
     id: int
     label: str
     probability: float
-    track_id: int
     time_in: datetime
     time_out: datetime
     _detections: Dict[str, List[float]]
+    video_ids: List[int]
 
     @classmethod
     def from_dict(cls, object_data: Dict[str, Any]):
@@ -25,11 +25,11 @@ class Object:
         return cls(
             id=object_data["id"],
             label=object_data["label"],
-            track_id=object_data["track_id"],
             time_in=datetime.fromtimestamp(object_data["label"]),
             time_out=datetime.fromtimestamp(object_data["label"]),
             probability=object_data["probability"],
             _detections=object_data["_detections"],
+            video_ids=object_data["video_ids"],
         )
 
 

--- a/src/ui/projects/templates/projects/job.html
+++ b/src/ui/projects/templates/projects/job.html
@@ -220,7 +220,9 @@
               >
                 {{ "%.5f" | format(object.probability) }}
               </td>
-              <td class="text-right px-2 border-r">{{ object.track_id }}</td>
+              <td class="text-right px-2 border-r">
+                {{ object.video_ids|join(', ') }}
+              </td>
               <td class="text-right px-2">
                 <a
                   id="preview-{{ loop.index }}"

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -81,7 +81,7 @@ def test_processing_and_scheduler():
         assert "probability" in obj
         assert "time_in" in obj
         assert "time_out" in obj
-        assert "track_id" in obj
+        assert "video_ids" in obj
 
 
 def test_video_loader():

--- a/tests/unit/core/integration/test_api.py
+++ b/tests/unit/core/integration/test_api.py
@@ -385,7 +385,7 @@ def test_get_done_job(setup, make_test_data):
         for obj in objs:
             assert "label" in obj
             assert "probability" in obj
-            assert "track_id" in obj
+            assert "video_ids" in obj
             assert "time_in" in obj
             assert "time_out" in obj
 

--- a/tests/unit/core/unit/test_object.py
+++ b/tests/unit/core/unit/test_object.py
@@ -188,3 +188,11 @@ def test_object_from_api_multiple():
 
     assert obj1.probability == pytest.approx(0.4)
     assert obj2.probability == pytest.approx(0.9)
+
+
+@pytest.mark.usefixtures("make_test_obj")
+def test_video_ids(make_test_obj: List[Object]):
+    """Test video_ids property of object."""
+    obj = make_test_obj[0]
+
+    assert obj.video_ids == [1]

--- a/tests/unit/core/unit/test_schema.py
+++ b/tests/unit/core/unit/test_schema.py
@@ -18,7 +18,7 @@ def test_object():
             model.Detection(model.BBox(10, 20, 30, 40), 0.1, 2, 4, 4, 1),
             model.Detection(model.BBox(10, 20, 30, 40), 0.3, 2, 5, 5, 1),
         ],
-        track_id=1,
+        video_ids=[1],
         time_in=datetime(2020, 3, 28, 10, 20, 30),
         time_out=datetime(2020, 3, 28, 10, 20, 40),
     )
@@ -29,3 +29,4 @@ def test_object():
         schema.get_label(1): [0.7, 0.8, 0.3],
         schema.get_label(2): [0.1, 0.3],
     }
+    assert obj.video_ids[0] == 1


### PR DESCRIPTION
`core api` now include a list of `video_ids` for each `Object` and `ui` using it to populate object table for a job. Closing #37.

Example:
![video_id](https://user-images.githubusercontent.com/43438127/124115665-5f983380-da6e-11eb-9b47-8c70e1475c1c.png)
