### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,22 @@
+# .github/dependabot.yaml
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "github-action"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/src/ui"
+    labels:
+      - npm
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    labels:
+      - pip
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,19 +4,13 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    labels:
-      - "github-action"
     schedule:
       interval: "daily"
   - package-ecosystem: "npm"
     directory: "/src/ui"
-    labels:
-      - npm
     schedule:
       interval: "daily"
   - package-ecosystem: "pip"
     directory: "/"
-    labels:
-      - pip
     schedule:
       interval: "daily"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
     paths:
+      - "setup.cfg"
       - "src/**"
       - "tests/**"
 


### PR DESCRIPTION
Ref.: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates

Dummy fork with current updates. https://github.com/MindTooth/solriksolen/pulls

Should maybe pin more to make sure that nothing breaks.