### PR TITLE
test: fix test for windows when grabbing metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-ast
         name: Check Python AST
@@ -19,28 +19,28 @@ repos:
           )
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.9.1
     hooks:
       - id: isort
         name: Sort imports (core)
         additional_dependencies: [toml]
         files: ^src/
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.6b0
     hooks:
       - id: black
         name: Format code (Python)
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.0.0
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.3.2
     hooks:
       - id: prettier
         name: Format other code (CSS, HTML, JS, MD, TOML, YAML)
         additional_dependencies:
-          - prettier@2.3.0
+          - prettier@2.3.2
           - "prettier-plugin-toml"
         types: [file]
         files: \.(css|html|js|markdown|md|toml|yaml|yml)$
@@ -49,13 +49,13 @@ repos:
             src/ui/static/dist
           )
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v4.1.0
+    rev: v5.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.902
+    rev: v0.910
     hooks:
       - id: mypy
         name: Run mypy

--- a/tests/unit/core/unit/test_video.py
+++ b/tests/unit/core/unit/test_video.py
@@ -1,4 +1,5 @@
 """Tests for `Video` class."""
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -178,10 +179,16 @@ def test_get_metadata_exception():
     with pytest.raises(FileNotFoundError):
         _ = _get_video_metadata("./tests/not_here.mp4")
 
-    with pytest.raises(RuntimeError):
-        _ = _get_video_metadata(
-            str((Path(__file__).parent / "abbor.png").resolve())
-        )
+    if os.name == "nt":
+        with pytest.raises(FileNotFoundError):
+            _ = _get_video_metadata(
+                str((Path(__file__).parent / "abbor.png").resolve())
+            )
+    else:
+        with pytest.raises(RuntimeError):
+            _ = _get_video_metadata(
+                str((Path(__file__).parent / "abbor.png").resolve())
+            )
 
 
 def test_release(make_test_video):


### PR DESCRIPTION
Windows fails earlier when attempting to grab metadata from OpenCV
resulting in `FileNotFoundError` instead of `RuntimeError`.

Not sure if this is the correct "fix", or if we should spend more time to corrent `_get_video_metadata()`?

All other test are passing.