### PR TITLE
refactor: start use `job.stats` in ui and stop sending `job._objects` 

### DIFF
--- a/src/core/api/schema.py
+++ b/src/core/api/schema.py
@@ -132,7 +132,6 @@ class JobBare(JobBase):
 
     id: int
     status: model.Status
-    object_count: int
     video_count: int
     progress: int
     stats: JobStat
@@ -149,7 +148,6 @@ class Job(JobBase):
     id: int
     status: model.Status
     location: str
-    objects: List[Object] = []
     videos: List[Video] = []
     progress: int
     stats: JobStat

--- a/src/ui/projects/model.py
+++ b/src/ui/projects/model.py
@@ -47,12 +47,12 @@ class JobBare(JobBase):
     """Holds the base data of a Job."""
 
     _status: str
-    object_count: int
     video_count: int
     progress: int
     id: Optional[int] = None
     project_id: Optional[int] = None
     project_name: Optional[str] = None
+    stats: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_dict(
@@ -68,8 +68,8 @@ class JobBare(JobBase):
             project_id=project_id,
             project_name=project_name,
             progress=job_data["progress"],
-            object_count=job_data["object_count"],
             video_count=job_data["video_count"],
+            stats=job_data["stats"],
         )
 
 
@@ -79,11 +79,11 @@ class Job(JobBase):
 
     _status: str
     videos: List[str]
-    _objects: List[Object]
     id: Optional[int] = None
     project_id: Optional[int] = None
     project_name: Optional[str] = None
     progress: Optional[int] = None
+    stats: Optional[Dict[str, Any]] = None
 
     def to_post_dict(self) -> Dict[str, Union[str | List[str]]]:
         """Return prepared dict for posting.
@@ -109,11 +109,6 @@ class Job(JobBase):
         cls, job_data: Dict[str, Any], project_id: int, project_name: str
     ) -> Job:
         """Create job from dict data."""
-        job_objects: List[Object] = list()
-
-        for job_object in list(job_data["_objects"]):
-            job_objects.append(Object(**job_object))
-
         return cls(
             _status=job_data["_status"],
             description=job_data["description"],
@@ -123,22 +118,13 @@ class Job(JobBase):
             project_id=project_id,
             project_name=project_name,
             videos=job_data["videos"],
-            _objects=job_objects,
             progress=job_data["progress"],
+            stats=job_data["stats"],
         )
 
-    def get_object_stats(self) -> Dict[str, int]:
+    def get_object_stats(self) -> Optional[Dict[str, Any]]:
         """Return total stat for all objects inside the job."""
-        object_count: Dict[str, int] = dict()
-
-        for obj in self._objects:
-            res = object_count.get(obj.label)
-            if not res:
-                object_count[obj.label] = 1
-            else:
-                object_count[obj.label] += 1
-
-        return object_count
+        return self.stats
 
 
 @dataclass

--- a/src/ui/projects/templates/projects/job.html
+++ b/src/ui/projects/templates/projects/job.html
@@ -120,19 +120,21 @@
             <li class="table-row">
               <span class="table-cell w-full">Objects</span
               ><span class="table-cell text-right"
-                >{{ job._objects|length }}</span
+                >{{ job.stats["total_objects"] }}</span
               >
             </li>
             <li class="table-row">
               <span class="table-cell w-full">Species</span
-              ><span class="table-cell text-right">{{ obj_stats|length }}</span>
+              ><span class="table-cell text-right"
+                >{{ job.stats["total_labels"] }}</span
+              >
             </li>
           </ul>
         </div>
         <div class="w-1/2">
           <h5 class="block text-center font-semibold mb-2">Counter</h5>
           <ul class="pl-8 border-l border-gray-100 table pr-4">
-            {% for label, count in obj_stats.items()|sort %}
+            {% for label, count in job.stats["labels"].items()|sort %}
             <li class="table-row">
               <span class="table-cell w-full">{{ label }}</span
               ><span class="table-cell text-right">{{ count }}</span>
@@ -179,14 +181,11 @@
               d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
             ></path>
           </svg>
-          Objects
-          <!-- TODO: this will not work longer, but is this display needed with datatables?
-	   ({{ job._objects|length }})
-	  -->
+          Objects ({{ job.stats["total_objects"] }})
         </label>
       </h3>
       <div class="border-2">
-        {% if job._objects|length > 0 %}
+        {% if job._status == "Done" %}
         <table id="object_list" class="display table-auto w-full border">
           <thead class="bg-gray-100 border-b">
             <tr class="font-bold">

--- a/src/ui/projects/templates/projects/partials/job_box.html
+++ b/src/ui/projects/templates/projects/partials/job_box.html
@@ -49,7 +49,7 @@
         stroke-width="2"
         d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"
       ></path></svg
-    >{{ job.object_count }} objects
+    >{{ job.stats["total_objects"] }} objects
   </div>
 </div>
 <div class="flex flex-row justify-end items-center">

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -74,14 +74,10 @@ def test_processing_and_scheduler():
     assert job_data["_status"] == "Done"
     assert job_data["progress"] == 100
 
-    objects = job_data["_objects"]
-
-    for obj in objects:
-        assert "label" in obj
-        assert "probability" in obj
-        assert "time_in" in obj
-        assert "time_out" in obj
-        assert "video_ids" in obj
+    assert "stats" in job_data
+    assert "labels" in job_data["stats"]
+    assert "total_objects" in job_data["stats"]
+    assert "total_labels" in job_data["stats"]
 
 
 def test_video_loader():

--- a/tests/unit/core/integration/test_api.py
+++ b/tests/unit/core/integration/test_api.py
@@ -272,7 +272,6 @@ def test_add_and_get_job(setup):
                 "location": "test",
                 "id": job_id,
                 "status": "Pending",
-                "object_count": 0,
                 "video_count": 0,
                 "progress": 0,
                 "stats": {"total_objects": 0, "total_labels": 0, "labels": {}},
@@ -358,7 +357,6 @@ def test_get_job(setup):
             "id": job_id,
             "name": "Job name",
             "_status": "Pending",
-            "_objects": [],
             "videos": [],
             "location": "test",
             "progress": 0,
@@ -381,27 +379,17 @@ def test_get_done_job(setup, make_test_data):
 
         assert "id" in data
         assert "_status" in data
-        assert "_objects" in data
-
-        objs = data["_objects"]
-        assert len(objs) == 2
-
-        for obj in objs:
-            assert "label" in obj
-            assert "probability" in obj
-            assert "video_ids" in obj
-            assert "time_in" in obj
-            assert "time_out" in obj
+        assert "stats" in data
 
 
 def test_project_not_existing(setup):
     """Test posting a new job to a project and getting list of jobs."""
     with TestClient(api.core_api) as client:
 
-        response = client.get(f"/projects/0/jobs")
+        response = client.get("/projects/0/jobs")
         assert response.status_code == 404
 
-        response = client.get(f"/projects/abc/jobs")
+        response = client.get("/projects/abc/jobs")
         assert response.status_code == 422
 
         response = client.post(

--- a/tests/unit/ui/test_ui.py
+++ b/tests/unit/ui/test_ui.py
@@ -64,9 +64,13 @@ def mock_client(requests_mock):
         "location": "string",
         "id": 1,
         "_status": "Pending",
-        "_objects": [],
         "videos": [],
         "progress": 0,
+        "stats": {
+            "total_objects": 0,
+            "total_labels": 0,
+            "labels": {},
+        },
     }
     job_done = {
         "name": "string",
@@ -74,9 +78,15 @@ def mock_client(requests_mock):
         "location": "string",
         "id": 2,
         "_status": "Done",
-        "_objects": [],
         "videos": [],
         "progress": 100,
+        "stats": {
+            "total_objects": 1,
+            "total_labels": 1,
+            "labels": {
+                "Abbor": 1,
+            },
+        },
     }
 
     # mock for Client.get_projects() call to core api


### PR DESCRIPTION
- `core` api stop sending list of objects as part of a `Job`.
- start using the `job.stats` in `ui` model and template.
Closing #80