### PR TITLE
chore(release): use setuptools_scm for dynamic version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dmypy.json
 
 # Make
 .make.deps
+
+# setuptools_scm
+src/nina/version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,9 @@
 graft src
+prune src/ui/node_modules
 graft tests
 
 include LICENSE
 include README.md
-include tox.ini .pre-commit-config.yaml pyproject.toml
+include .pre-commit-config.yaml pyproject.toml
 
 global-exclude *.py[cod] __pycache__/* *.so *.dylib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,14 @@ python_files = ["test_*.py", "*_test.py", "tests.py"]
 [tool.coverage.run]
 branch = true
 source = ["src"]
-omit = ["*/.tox/*", "*/__main__.py", "*/setup.py", "*/.venv*/*", "*/venv*/*"]
+omit = [
+  "*/.tox/*",
+  "*/__main__.py",
+  "*/setup.py",
+  "*/.venv*/*",
+  "*/venv*/*",
+  "src/nina/version.py"
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,11 @@ authors = [
 license = "GPL-3.0"
 
 [build-system]
-requires = ["setuptools >= 35.0.2", "setuptools_scm >= 2.0.0, <3"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/nina/version.py"
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,10 @@
 [metadata]
 name = nina
-version = attr: nina.__version__
 description = Application to detect, track and calculate statistics of objects in video.
 long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/MindTooth/fish-code
+author = Birger Johan Nordølum, Eirik Osland Lavik, Kristian André Dahl Haugen, Tom-Ruben Traavik Kvalvaag
 license = GPL-3.0
 license_file = LICENSE
 classifiers =
@@ -40,6 +41,9 @@ python_requires = >=3.8
 include_package_data = True
 package_dir =
     =src
+setup_requires =
+    setuptools>=42.0
+    setuptools-scm>=3.4
 zip_safe = False
 
 [options.packages.find]

--- a/src/nina/__init__.py
+++ b/src/nina/__init__.py
@@ -1,3 +1,9 @@
 # pragma: no cover
 # noqa: D104
-__version__ = "1.0.0-rc1"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("nina")
+except PackageNotFoundError:  # pragma: no cover
+    # package is not installed
+    pass


### PR DESCRIPTION
Read more: https://github.com/pypa/setuptools_scm/

Instead of hardcoding the version, we can utilize the `setuptools_scm` plugin to dynamically extract the version from tags.  Running `python -m build` generates the versions based on the dags.  E.g. `nina-1.0.3.dev0+g8d3eac0.d20210721-py3-none-any.whl`.

---

```py
# src/nina/__init__.py
from importlib.metadata import version, PackageNotFoundError

try:
    __version__ = version("nina")
    print(__version__)  # Just for debug
except PackageNotFoundError:
    # package is not installed
    pass
```

Print this when there are unstaged changes:
>1.0.3.dev0+g8d3eac0.d20210721

Else, when clean and tagged:

>1.0.4