### PR TITLE
test(config): add additional test

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,10 +1,2 @@
 """Configuration parsing package."""
-from .config import (
-    find_config_directory,
-    find_data_directory,
-    get_config_file_path,
-    get_default_config,
-    get_video_root_path,
-    load_config,
-    write_config,
-)
+from .config import *

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -3,6 +3,7 @@ import configparser
 import logging
 import os
 import sys
+from os import name as os_name
 from pathlib import Path
 from typing import Final, Optional
 
@@ -13,7 +14,12 @@ DATABASE_FILE_NAME: Final[str] = "data.db"
 APP_DIRECTORY_NAME: Final[str] = "nina"
 
 
-def find_config_directory() -> Path:  # Pragma: no cover
+def get_os_name() -> str:
+    """Get operation system name from `os.name`."""
+    return os_name
+
+
+def find_config_directory() -> Path:
     """Get configuration directory.
 
     Checks the operating system if it is windows or unix based. Uses enviroment
@@ -26,32 +32,36 @@ def find_config_directory() -> Path:  # Pragma: no cover
     Path    :
         Path object to the configuration directory.
     """
-    if os.name == "nt" and "LOCALAPPDATA" in os.environ:
+    if (
+        get_os_name() == "nt" and "LOCALAPPDATA" in os.environ
+    ):  # pragma: no cover
         confighome = Path(os.environ["LOCALAPPDATA"])
-    elif os.name == "posix" and "XDG_CONFIG_HOME" in os.environ:
+    elif get_os_name() == "posix" and "XDG_CONFIG_HOME" in os.environ:
         confighome = Path(os.environ["XDG_CONFIG_HOME"])
     elif "HOME" in os.environ:
-        confighome = Path(os.path.join(os.environ["HOME"], ".config"))
+        confighome = Path(os.environ["HOME"]) / ".config"
     else:
         # Unable to find config directory, defaulting to current directory.
         return Path().resolve()
 
-    return Path(os.path.join(confighome, APP_DIRECTORY_NAME))
+    return Path(confighome) / APP_DIRECTORY_NAME
 
 
-def find_data_directory() -> Path:  # Pragma: no cover
+def find_data_directory() -> Path:
     """Find application data directory."""
-    if os.name == "nt" and "LOCALAPPDATA" in os.environ:
+    if (
+        get_os_name() == "nt" and "LOCALAPPDATA" in os.environ
+    ):  # pragma: no cover
         confighome = Path(os.environ["LOCALAPPDATA"])
-    elif os.name == "posix" and "XDG_DATA_HOME" in os.environ:
+    elif get_os_name() == "posix" and "XDG_DATA_HOME" in os.environ:
         confighome = Path(os.environ["XDG_DATA_HOME"])
     elif "HOME" in os.environ:
-        confighome = Path(os.path.join(os.environ["HOME"], ".local", "share"))
+        confighome = Path(os.environ["HOME"]) / ".local" / "share"
     else:
         # Unable to find data directory, defaulting to current directory.
         return Path().resolve()
 
-    return Path(os.path.join(confighome, APP_DIRECTORY_NAME))
+    return Path(confighome) / APP_DIRECTORY_NAME
 
 
 def get_config_file_path() -> str:
@@ -87,7 +97,7 @@ def get_video_root_path() -> str:
     str     :
         Path represented as a string to the users home directory.
     """
-    if os.name == "nt" and "HOMEPATH" in os.environ:
+    if get_os_name() == "nt" and "HOMEPATH" in os.environ:  # pragma: no cover
         return str(Path(os.environ["HOMEPATH"]))
     elif "HOME" in os.environ:
         return str(Path(os.environ["HOME"]))

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1,19 +1,27 @@
 """Unit test of config package functionality."""
+from os.path import isfile
+from pathlib import Path
+from unittest.mock import patch
 import configparser
 import logging
-import pytest
-from unittest.mock import patch
 import os
+import pytest
+import sys
 
-import config
-from os.path import isfile
+from config import find_config_directory
+from config import find_data_directory
+from config import load_config
+from config import get_default_config
+from config import write_config
+from config import get_os_name
+from config import get_video_root_path
 
 logger = logging.getLogger(__name__)
 
 
-def test_load_default_config():
+def test_load_default_config() -> None:
     """Checks the default config to contain correct sections."""
-    parser = config.load_config(default=True)
+    parser = load_config(default=True)
 
     assert set(parser.sections()) == {
         "GLOBAL",
@@ -23,59 +31,211 @@ def test_load_default_config():
         "UI",
     }
     assert parser.get("DEFAULT", "hostname") == "127.0.0.1"
-    assert parser.getboolean("DEFAULT", "enable") == True
-    assert parser.getboolean("GLOBAL", "development") == False
+    assert parser.getboolean("DEFAULT", "enable") is True
+    assert parser.getboolean("GLOBAL", "development") is False
 
 
 @patch("os.path.isfile")
-def test_load_config(mock_isfile):
+def test_load_config(mock_isfile) -> None:
     """Checks that config can be read from disk at default config location."""
     mock_isfile.return_value = True
     with patch.object(configparser.ConfigParser, "read_file") as mock_method:
-        config.load_config(path="./tests/integration/test_data/test_config.ini")
+        load_config(path="./tests/integration/test_data/test_config.ini")
 
     mock_method.assert_called_once()
 
 
 @patch("os.path.isfile")
-def test_load_config_not_found(mock_isfile):
+def test_load_config_not_found(mock_isfile) -> None:
     """Checks that config can be read from disk at default config location."""
     mock_isfile.return_value = False
     with patch.object(configparser.ConfigParser, "read_file") as mock_method:
-        data = config.load_config()
+        data = load_config()
 
     mock_method.assert_not_called()
-    assert data.__eq__(config.get_default_config())
+    assert data.__eq__(get_default_config())
+
+
+@patch("os.path.isfile")
+def test_load_config_oserror(mock_isfile, caplog) -> None:
+    """Checks config error handling."""
+    mock_isfile.return_value = True
+    with patch.object(configparser.ConfigParser, "read_file") as mock_method:
+
+        def side_effect(args):
+            raise OSError
+
+        mock_method.side_effect = side_effect
+        with caplog.at_level(logging.ERROR):
+            parser = load_config()
+            assert (
+                "Unable to read configuration file from"
+                in caplog.records[0].getMessage()
+            )
+            assert parser.__eq__(get_default_config())
 
 
 @patch("builtins.open")
-def test_write_config(mock_open):
+def test_write_config(mock_open) -> None:
     """Checks that config can be written to disk at default config location."""
     with patch.object(configparser.ConfigParser, "write") as mock_method:
-        config.write_config(config.get_default_config())
+        write_config(get_default_config())
 
     mock_method.assert_called_once()
     mock_open.assert_called_once()
 
 
-def test_read_config_garbage_data(caplog):
+def test_read_config_garbage_data(caplog) -> None:
     """Test that malformed configuration files throws error, and gives default conf."""
     with caplog.at_level(logging.WARNING):
-        parser = config.load_config(
+        parser = load_config(
             path="./tests/integration/test_data/malformed_config.ini"
         )
         assert (
             caplog.records[0].getMessage()
             == "Parsing error occured in config file."
         )
-        assert parser.__eq__(config.get_default_config())
+        assert parser.__eq__(get_default_config())
 
     with caplog.at_level(logging.WARNING):
-        parser = config.load_config(
+        parser = load_config(
             path="./tests/integration/test_data/missing_header.ini"
         )
         assert (
             caplog.records[2].getMessage()
             == "Config file is missing section header."
         )
-        assert parser.__eq__(config.get_default_config())
+        assert parser.__eq__(get_default_config())
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Not run on Windows")
+@pytest.mark.parametrize(
+    "name, env, config_path, expected",
+    [
+        (
+            "posix",
+            "XDG_CONFIG_HOME",
+            "/posix/test/path",
+            "/posix/test/path/nina",
+        ),
+        ("DUMMY", "HOME", "/home/test/path", "/home/test/path/.config/nina"),
+        ("DUMMY", "DUMMY", "DUMMY", str(Path().resolve())),
+    ],
+)
+def test_find_config_dir(
+    name: str, env: str, config_path: str, expected: str
+) -> None:
+    """Test finding application config directory based on os."""
+    with patch("os.name", return_value=name), patch.dict(
+        "os.environ", {env: config_path}, clear=True
+    ):
+        assert find_config_directory() == Path(expected)
+
+
+@pytest.mark.skipif(not os.name == "nt", reason="Only run on Windows")
+@pytest.mark.parametrize(
+    "env, config_path, expected",
+    [
+        (
+            "LOCALAPPDATA",
+            "C:\\User\\test\\path",
+            "C:\\User\\test\\path\\nina",
+        ),
+    ],
+)
+def test_find_config_dir_windows(
+    env: str, config_path: str, expected: str
+) -> None:
+    """Test finding application config directory based on os."""
+    with patch.dict("os.environ", {env: config_path}, clear=True):
+        assert find_config_directory() == Path(expected)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Not run on Windows")
+@pytest.mark.parametrize(
+    "name, env, config_path, expected",
+    [
+        ("posix", "XDG_DATA_HOME", "/posix/test/path", "/posix/test/path/nina"),
+        (
+            "DUMMY",
+            "HOME",
+            "/home/test/path",
+            "/home/test/path/.local/share/nina",
+        ),
+        ("DUMMY", "DUMMY", "DUMMY", str(Path().resolve())),
+    ],
+)
+def test_find_data_dir(
+    name: str, env: str, config_path: str, expected: str
+) -> None:
+    """Test finding application data directory based on os."""
+    with patch("os.name", name), patch.dict(
+        "os.environ", {env: config_path}, clear=True
+    ):
+        assert find_data_directory() == Path(expected)
+
+
+@pytest.mark.skipif(not os.name == "nt", reason="Only run on Windows")
+@pytest.mark.parametrize(
+    "env, config_path, expected",
+    [
+        (
+            "LOCALAPPDATA",
+            "C:\\User\\test\\path",
+            "C:\\User\\test\\path\\nina",
+        ),
+    ],
+)
+def test_find_data_dir_windows(
+    env: str, config_path: str, expected: str
+) -> None:
+    """Test finding application data directory based on os."""
+    with patch.dict("os.environ", {env: config_path}, clear=True):
+        assert find_data_directory() == Path(expected)
+
+
+@pytest.mark.skipif(not os.name == "nt", reason="Only run on Windows")
+def test_get_os_name_windows() -> None:
+    """Test get os name."""
+    assert get_os_name() == "nt"
+
+
+@pytest.mark.skipif(not os.name == "posix", reason="Only run on posix")
+def test_get_os_name_posix() -> None:
+    """Test get os name."""
+    assert get_os_name() == "posix"
+
+
+@pytest.mark.skipif(not os.name == "nt", reason="Only run on Windows")
+@pytest.mark.parametrize(
+    "env, config_path, expected",
+    [
+        (
+            "HOMEPATH",
+            "C:\\User\\test\\path",
+            "C:\\User\\test\\path",
+        ),
+    ],
+)
+def test_video_root_dir_windows(
+    env: str, config_path: str, expected: str
+) -> None:
+    """Test finding application video root directory based on os."""
+    with patch.dict("os.environ", {env: config_path}, clear=True):
+        assert get_video_root_path() == expected
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Not run on Windows")
+@pytest.mark.parametrize(
+    "env, config_path, expected",
+    [
+        ("HOME", "/home/test", "/home/test"),
+        ("DUMMY", "DUMMY", str(Path(sys.executable).anchor)),
+    ],
+)
+def test_video_root_dir_others(
+    env: str, config_path: str, expected: str
+) -> None:
+    """Test finding application video root directory based on os."""
+    with patch.dict("os.environ", {env: config_path}, clear=True):
+        assert get_video_root_path() == expected


### PR DESCRIPTION
Add os specific tests to config.
This should have been included in #73 but was left out due to a bad rebase.
Credit to @tomrtk for the commits