### PR TITLE
fix: config docs and save config file if not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,16 @@ interface.
 
 ## Configuration
 
-TODO
+A configuration file(`config.ini`) is saved to a local path if not found at first start-up.
+Path it is saved to depend on operation system as specified below:
+
+- linux/unix:
+  - If `XDG_CONFIG_HOME` environment variable is set, it is saved to a folder
+    `nina` in this location.
+  - Else, it is saved to `~/.config/nina/`.
+- windows: config is saved to `LOCALAPPDATA`.
+- if it should not be able to determine where to save the config, it will be saved
+  to the current working directory, where the solution are started from.
 
 ## Development
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -185,13 +185,14 @@ def load_config(
     else:
         logger.warning(
             f"Could not find config file at {config_path}, using defaults."
+            f"Saving it to {config_path}"
         )
-        return get_default_config()
+        config = get_default_config()
+        write_config(config, config_path)
+        return config
 
 
-def write_config(config: configparser.ConfigParser) -> None:
+def write_config(config: configparser.ConfigParser, path: str) -> None:
     """Write a ConfigParser object to disk at the applications config file path."""
-    # TODO: Error check
-    Path(find_config_directory()).mkdir(parents=True, exist_ok=True)
-    with open(get_config_file_path(), "w") as configfile:
+    with open(path, "w") as configfile:
         config.write(configfile)


### PR DESCRIPTION
- filled in config section in readme.
- config is saved to disk if not found during startup.

Resolve #149