### PR TITLE
fix: remove project section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,3 @@
-[project]
-name = "nina"
-description = '''
-Application to detect, track and calculate statistics of objects in video.
-'''
-authors = [
-  "Birger Johan Nordølum",
-  "Eirik Osland Lavik",
-  "Kristian André Dahl Haugen",
-  "Tom-Ruben Traavik Kvalvaag"
-]
-license = "GPL-3.0"
-
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
@@ -22,9 +9,7 @@ write_to = "src/nina/version.py"
 profile = "black"
 line_length = 80
 multi_line_output = 3
-skip = [
-    "./src/vendor",
-]
+skip = ["./src/vendor"]
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION
remove project section to fix build error, due to setuptools starting to support pyproject.toml only project -- this is still a experimental feature and do not support editable installs.