### PR TITLE
fix: errors from mypy v0.950

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,9 @@ repos:
         additional_dependencies:
           - "sqlalchemy[mypy]"
           - "types-all"
+          # XXX: type issue with request.post files argument
+          # https://github.com/python/typeshed/issues/7724
+          - "types-requests==2.27.20"
         files: ^src/
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1

--- a/src/core/repository/object.py
+++ b/src/core/repository/object.py
@@ -37,7 +37,7 @@ class AbstractObjectRepository(abc.ABC):
         """Save and commit changes to repository."""
         raise NotImplementedError
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def remove(self, obj: model.Object) -> None:  # pragma: no cover
         """Delete object from repository."""
         raise NotImplementedError

--- a/src/core/repository/video.py
+++ b/src/core/repository/video.py
@@ -37,7 +37,7 @@ class AbstractVideoRepository(abc.ABC):
         """Save and commit changes to repository."""
         raise NotImplementedError
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def remove(self, vid: model.Video) -> None:  # pragma: no cover
         """Delete video from repository."""
         raise NotImplementedError
@@ -100,12 +100,12 @@ class SqlAlchemyVideoRepository(AbstractVideoRepository):
         """Commit and save changes."""
         self.session.commit()
 
-    def remove(self, obj: model.Video) -> None:
+    def remove(self, vid: model.Video) -> None:
         """Delete video from repository.
 
         Parameter
         ---------
-        obj : model.Video
+        vid : model.Video
            Video to remove
         """
-        self.session.delete(obj)
+        self.session.delete(vid)


### PR DESCRIPTION
fix errors from mypy in shown in pre-commit.ci run in #462.

- wrong abc decorator used in video and object repository
- change in type stub for `requests.post` `files` argument -- pinned
`types-requests` to older version in pre-commit config.