### PR TITLE
ci: disable dependabot version update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,7 +10,11 @@ updates:
     directory: "/src/ui"
     schedule:
       interval: "daily"
+    # Disable version updates for dependencies, only security updates
+    open-pull-requests-limit: 0
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    # Disable version updates for dependencies, only security updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
disable dependabot version update and only get security updates, until a 
time it supports grouped PRs.