### PR TITLE
ci: remove codecov from workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,15 +17,12 @@ on:
 
 jobs:
   tests:
-    name: Python ${{ matrix.python-version }} - ${{ matrix.tests }} - ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9]
-        tests: [integration, unit]
-    env:
-      COVERAGE_FILE: ${{ github.workspace }}/.coverage.${{ matrix.python-version }}-${{ matrix.tests }}
     steps:
       - name: Checkout code w/ LFS
         uses: nschloe/action-cached-lfs-checkout@v1
@@ -36,35 +33,10 @@ jobs:
       - name: Install Base Dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install --upgrade tox
-      - name: Run ${{ matrix.tests }} Tests
+          pip install --upgrade tox virtualenv
+      - name: Run tests on ${{ matrix.os }} with python ${{matrix.python-version }}
         run: |
-          tox -e ${{ matrix.tests }}
-      - uses: actions/upload-artifact@v3
-        if: ${{ matrix.python-version == 3.9 &&  matrix.os == 'ubuntu-latest' }}
-        with:
-          name: coverage-${{ matrix.tests }}
-          path: ${{ env.COVERAGE_FILE }}.*
-
-  upload-to-codecov:
-    name: Upload Coverage to Codecov
-    needs: [tests]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.x"
-      - name: Generate Coverage Report (XML)
+          tox -e py
+      - name: Make coverage report
         run: |
-          pip install --upgrade coverage[toml] covdefaults
-          coverage combine coverage-*
-          coverage xml
-      - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3.1.0
-        with:
-          fail_ci_if_error: true
+          tox -e coverage

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/MindTooth/fish-code/master.svg)](https://results.pre-commit.ci/latest/github/MindTooth/fish-code/master)
 [![GitHub](https://img.shields.io/github/license/MindTooth/fish-code)](./LICENSE)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/MindTooth/fish-code/Tests)](https://github.com/MindTooth/fish-code/actions/workflows/tests.yaml)
-[![codecov](https://codecov.io/gh/MindTooth/fish-code/branch/master/graph/badge.svg?token=ZQ3PSGY6P2)](https://codecov.io/gh/MindTooth/fish-code)
 
 Application to detect, track and calculate statistics of objects in video. With
 the option to view the statistics by using the UI or exporting to CSV.
@@ -209,17 +208,15 @@ so that tests can be executed separately or all at once.
 # to build and run tests for all supported versions:
 $ tox
 # or for a specific Python version or target:
-$ tox -e py39-integration
+$ tox -e py39
 ```
 
 Pass `-l` to `tox` to see all targets.
 
 ```sh
 $ tox -l
-py38-integration
-py38-unit
-py39-integration
-py39-unit
+py38
+py39
 coverage
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,12 +65,12 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 85
+fail_under = 87
 
 [tool.tox]
 legacy_tox_ini = '''
 [tox]
-envlist = py{38,39}-{integration,unit},
+envlist = py{38,39}
           coverage
 isolated_build = True
 skipsdist = True
@@ -83,8 +83,7 @@ deps =
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
 commands =
-    integration: coverage run -p -m pytest tests/integration {posargs}
-    unit: coverage run -p -m pytest tests/unit {posargs}
+    coverage run -p -m pytest {posargs}
 
 [testenv:coverage]
 deps =
@@ -96,5 +95,4 @@ setenv =
 commands = coverage combine
            coverage report -m
            coverage xml
-depends = py39-{integration,unit}
 '''


### PR DESCRIPTION
remove codecov from workflow and use `tox -e coverage` instead, coverage set to fail on coverage below 87%.

as part of this to get a proper coverage report, `unit` and `integration` targets in `tox` was unified to one target for each python version. this will result in some longer test time in `ci`, but will not need to sign up for codecov to get coverage in ci.