### PR TITLE
chore: disable mypy check for tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -111,5 +111,8 @@ no_implicit_optional = true
 warn_redundant_casts = true
 plugins = sqlalchemy.ext.mypy.plugin
 
+[mypy-tests.*]
+disallow_untyped_defs = false
+
 [mypy-vendor.*]
 ignore_errors = True


### PR DESCRIPTION
change mypy config to allow untyped functions of in `tests`