### PR TITLE
fix: fix mutable arguments and abstract class

### DIFF
--- a/src/core/model.py
+++ b/src/core/model.py
@@ -793,7 +793,7 @@ class Object:
     def __init__(
         self,
         label: int,
-        detections: list[Detection] = [],
+        detections: list[Detection] | None = None,
         track_id: int | None = None,
     ) -> None:
         """Create an Object.
@@ -810,7 +810,7 @@ class Object:
         self.id: int | None
         self.label: int = label
         self.probability: float = 0.0
-        self._detections: list[Detection] = detections
+        self._detections = detections if detections is not None else []
         self.track_id: int | None = track_id
         self.time_in: datetime | None = None
         self.time_out: datetime | None = None

--- a/src/tracing/tracker.py
+++ b/src/tracing/tracker.py
@@ -277,6 +277,7 @@ class AbstractTracker(abc.ABC):
     def __init__(self) -> None:
         self._objects: dict[int, Object] = dict()
 
+    @abc.abstractmethod
     def update(self, detections: list[Detection]) -> None:
         """Update the tracker."""
         raise NotImplementedError
@@ -285,10 +286,12 @@ class AbstractTracker(abc.ABC):
         """Return the object dict."""
         return self._objects
 
+    @abc.abstractmethod
     def get_false_positive(self) -> int:
         """Get the false positives from the tracker. Used for benchmarking."""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_misses(self) -> int:
         """Get the misses from the tracker. Used for benchmarking."""
         raise NotImplementedError

--- a/src/ui/projects/api.py
+++ b/src/ui/projects/api.py
@@ -140,7 +140,7 @@ class Client:
                 return decorator_call(request)
 
     @Api.call(status_code=200, acceptable_error=403)
-    def get(self, uri: str, params: Dict = {}) -> requests.Response:
+    def get(self, uri: str, params: Optional[Dict] = None) -> requests.Response:
         """Perform a GET request to `uri.
 
         Expects a successful call to return a status_code = 200.


### PR DESCRIPTION
fix bugs reported from bugbear.

```console
src/core/model.py:796:39: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
src/tracing/tracker.py:274:1: B024 AbstractTracker is an abstract base class, but it has no abstract methods. Remember to use the @abstractmethod decorator, potentially in conjunction with @classmethod, @property and/or @staticmethod.
src/ui/projects/api.py:143:44: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
```