### PR TITLE
test: integration tests fixture scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,8 @@ extras = testing
 allowlist_externals = coverage
 setenv =
   COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
+passenv =
+  CI
 commands =
   coverage run -p -m pytest {posargs}
 

--- a/src/detection/api.py
+++ b/src/detection/api.py
@@ -1,6 +1,7 @@
 """Module defining detection API."""
 
 import logging
+import os
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple, Union
@@ -28,6 +29,8 @@ model_fishy2_path = (
 if not model_fishy_path.exists() or model_fishy_path.is_dir():
     raise FileNotFoundError
 
+IN_CI = os.environ.get("CI", False)
+
 
 @detection_api.on_event("startup")  # type: ignore
 async def startup_event() -> None:
@@ -38,6 +41,7 @@ async def startup_event() -> None:
             "custom",
             path=str(model_fishy_path.resolve()),
             trust_repo=True,
+            skip_validation=True if IN_CI else False,
         ),
         640,
     )
@@ -60,6 +64,7 @@ async def startup_event() -> None:
             "custom",
             path=str(model_fishy2_path.resolve()),
             trust_repo=True,
+            skip_validation=True if IN_CI else False,
         ),
         768,
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,7 @@ from tracing.main import main as tracing_main  # type: ignore
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
+@pytest.fixture(scope="package")
 def tracing_api():
     """Start tracing API.
 
@@ -95,7 +95,7 @@ def check_api(
     assert ping(host, port)
 
 
-@pytest.fixture
+@pytest.fixture(scope="package")
 def detection_api():
     """Start detection API.
 
@@ -109,6 +109,6 @@ def detection_api():
         target=detection_main, args=(None,), daemon=True
     )
     detection_process.start()
-    check_api(max_tries=60, host="localhost", port="8003")
+    check_api(host="localhost", port="8003")
     yield
     detection_process.terminate()


### PR DESCRIPTION
Add `package` fixture scope to detection and tracking api fixtures to reduce number of times the api need to be created. These api's should be stateless, and it should reduce build/teardown time for each test. Also since we do not run anything in parallel it should be safe and not cause any test pollution.

I see a ~40 second faster run of all tests locally, compared to `master`. 

Should also maybe solve comment on rate-limit issues in `ci` in #558. 