### PR TITLE
ci: test groups in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,12 +9,18 @@ updates:
   - package-ecosystem: "npm"
     directory: "/src/ui"
     schedule:
-      interval: "daily"
-    # Disable version updates for dependencies, only security updates
-    open-pull-requests-limit: 0
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      ui-deps:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
-    # Disable version updates for dependencies, only security updates
-    open-pull-requests-limit: 0
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      pip-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/