### PR TITLE
chore: remove obsolete @types/datatables.net

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -14,7 +14,6 @@
       "devDependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.3",
-        "@types/datatables.net": "^1.10.24",
         "@types/jquery": "^3.5.14",
         "@types/jstree": "^3.3.41",
         "autoprefixer": "^10.4.12",
@@ -141,15 +140,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/@types/datatables.net": {
-      "version": "1.10.24",
-      "resolved": "https://registry.npmjs.org/@types/datatables.net/-/datatables.net-1.10.24.tgz",
-      "integrity": "sha512-Qb82/7Gn0bU36YLiv0MdaqKzhTLfRO9qPvFdkW0miQ6ATMG47aoPn2r//zTvGd3oPSt+Lzp1HSsjP6rZRuki8g==",
-      "dev": true,
-      "dependencies": {
-        "@types/jquery": "*"
       }
     },
     "node_modules/@types/jquery": {
@@ -2997,15 +2987,6 @@
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
-    },
-    "@types/datatables.net": {
-      "version": "1.10.24",
-      "resolved": "https://registry.npmjs.org/@types/datatables.net/-/datatables.net-1.10.24.tgz",
-      "integrity": "sha512-Qb82/7Gn0bU36YLiv0MdaqKzhTLfRO9qPvFdkW0miQ6ATMG47aoPn2r//zTvGd3oPSt+Lzp1HSsjP6rZRuki8g==",
-      "dev": true,
-      "requires": {
-        "@types/jquery": "*"
-      }
     },
     "@types/jquery": {
       "version": "3.5.14",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.3",
-    "@types/datatables.net": "^1.10.24",
     "@types/jquery": "^3.5.14",
     "@types/jstree": "^3.3.41",
     "autoprefixer": "^10.4.12",


### PR DESCRIPTION
This is already included in the upstream source.

https://github.com/DataTables/DataTablesSrc/tree/master/types