### PR TITLE
Second attempt at normalizing path input for jstree tree

### DIFF
--- a/src/core/services.py
+++ b/src/core/services.py
@@ -646,16 +646,19 @@ def get_directory_listing(
     Dict
         jsTree formatted json containing information about root node at path.
     """
+    video_root = config.get(
+        "CORE",
+        "video_root_path",
+        fallback=str(get_video_root_path()),
+    )
     if path is None:
-        directory = config.get(
-            "CORE",
-            "video_root_path",
-            fallback=str(get_video_root_path()),
-        )
+        directory = video_root
     else:
         directory = path
 
     normalized_path = pathlib.Path(os.path.normpath(directory))
+    if not str(normalized_path).startswith(video_root):
+        raise NotADirectoryError("fishy path")
 
     tree: list[dict[str, Any] | str | None] = []
     root_node: dict[str, Any] = {}


### PR DESCRIPTION
Second attempt, stolen from https://github.com/tomrtk/fish-code/pull/598#issuecomment-1654584841. 😉 

I see a lot of checks further below.  I feel that this could be cleaned up a bit.  I'll see if I clean it up a bit.

Also, getting the `video_root` config option should have been a helper somewhere.  This logic should not be just inside this function.  I guess it's the same other places too when trying to access a config option.