### PR TITLE
Bump setuptools requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,8 @@ nina-ui = "ui.run:serve"
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=42",
-  "setuptools_scm[toml]>=3.4",
-  "wheel",
+  "setuptools>=61",
+  "setuptools_scm[toml]>=6.2",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Version 61 is needed for parsing pyproject.toml correctly.

Removed wheel as `python3 -m build` works just fine.  Maybe `build` should have been there instead. 🤔 