### PR TITLE
chore: switch to faster black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     rev: 1.1.0
     hooks:
       - id: pyproject-fmt
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.9.1
     hooks:
       - id: black


### PR DESCRIPTION
From the official change log.

> Black now has an [official pre-commit mirror](https://github.com/psf/black-pre-commit-mirror). Swapping https://github.com/psf/black to https://github.com/psf/black-pre-commit-mirror in your .pre-commit-config.yaml will make Black about 2x faster (https://github.com/psf/black/pull/3828)

https://github.com/psf/black/releases/tag/23.9.0